### PR TITLE
Update DataToolUtils.java

### DIFF
--- a/src/main/java/com/webank/weid/util/DataToolUtils.java
+++ b/src/main/java/com/webank/weid/util/DataToolUtils.java
@@ -568,7 +568,9 @@ public final class DataToolUtils {
         String signature,
         BigInteger publicKey)
         throws SignatureException {
-
+        if (message == null) {
+            return false;
+        }
         Sign.SignatureData signatureData = convertBase64StringToSignatureData(signature);
         BigInteger extractedPublicKey = signatureToPublicKey(message, signatureData);
         return extractedPublicKey.equals(publicKey);


### PR DESCRIPTION
在传入的message为null的情况下，会有报空指针的风险，加判空检查。
