### PR TITLE
adaptive jdk

### DIFF
--- a/.ci/script/build-ci.sh
+++ b/.ci/script/build-ci.sh
@@ -7,6 +7,8 @@ weid_config_tpl=${java_source_code_dir}/src/main/resources/weidentity.properties
 weid_config=${java_source_code_dir}/src/main/resources/weidentity.properties
 font=${java_source_code_dir}/src/main/resources/NotoSansCJKtc-Regular.ttf
 
+JAVA_OPTS='-Djdk.tls.namedGroups="secp256k1"'
+
 function modify_config()
 {
     echo "begin to modify sdk config..."
@@ -87,7 +89,7 @@ function deploy_contract()
         CLASSPATH=${CLASSPATH}:${jar_file}
     done
 
-    java -cp "$CLASSPATH" com.webank.weid.contract.deploy.DeployContract
+    java ${JAVA_OPTS} -cp "$CLASSPATH" com.webank.weid.contract.deploy.DeployContract
     echo "contract deployment done."
 }
 

--- a/build-tools/bin/run.sh
+++ b/build-tools/bin/run.sh
@@ -6,7 +6,9 @@ echo $source_code_dir
 cd $source_code_dir
 
 if [ -d dist/ ];then
-    rm -rf dist/
+    rm -rf dist/app
+    rm -rf dist/conf
+    rm -rf dist/*.jar
 fi
 
 gradle clean build -x checkMain -x checkTest -x spotbugsMain -x spotbugsTest -x test

--- a/build-tools/bin/setup.sh
+++ b/build-tools/bin/setup.sh
@@ -147,7 +147,9 @@ function gradle_build_sdk()
 	
     cd ${java_source_code_dir}/
     if [ -d dist/ ];then
-	rm -rf dist/
+        rm -rf dist/app
+        rm -rf dist/conf
+        rm -rf dist/*.jar
     fi
     gradle clean build -x checkMain -x checkTest -x spotbugsMain -x spotbugsTest -x test
     echo "compile java code done."

--- a/build-tools/bin/setup.sh
+++ b/build-tools/bin/setup.sh
@@ -8,6 +8,8 @@ app_xml_config=${java_source_code_dir}/src/main/resources/fisco.properties
 weid_config_tpl=${java_source_code_dir}/src/main/resources/weidentity.properties.tpl
 weid_config=${java_source_code_dir}/src/main/resources/weidentity.properties
 
+JAVA_OPTS='-Djdk.tls.namedGroups="secp256k1"'
+
 CLASSPATH=${java_source_code_dir}/dist/conf
 
 for jar_file in ${java_source_code_dir}/dist/lib/*.jar
@@ -160,7 +162,7 @@ function deploy_contract()
 	CLASSPATH=${CLASSPATH}:${jar_file}
 	done
 
-    java -cp "$CLASSPATH" com.webank.weid.contract.deploy.DeployContract
+    java ${JAVA_OPTS} -cp "$CLASSPATH" com.webank.weid.contract.deploy.DeployContract
     echo "contract deployment done."
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -81,11 +81,11 @@ List apache_commons = [
 ]
 
 List jmockit = [
-        "org.jmockit:jmockit:1.9"
+        "org.jmockit:jmockit:1.47"
 ]
 
 List json = [
-        "com.fasterxml.jackson.core:jackson-databind:2.8.8.1",
+        "com.fasterxml.jackson.core:jackson-databind:2.10.0",
         "com.github.fge:json-schema-validator:2.2.6",
         "com.github.reinert:jjschema:1.16"
 ]
@@ -179,6 +179,11 @@ task javadocJar(type: Jar, dependsOn: javadoc) {
     from 'build/docs/javadoc'
 }
 
+test {
+   systemProperty "jdk.tls.namedGroups", "${jdkTlsNamedGroups}"
+   jvmArgs "-javaagent:${classpath.find { it.name.contains("jmockit") }.absolutePath}"
+}
+
 artifacts {
     archives jar
     archives sourcesJar
@@ -225,7 +230,11 @@ if (!gradle.startParameter.isOffline()) {
             html.enabled false
         }
     }
-
+    
+	jacoco{
+        toolVersion = "0.8.5"
+    }
+    
     check.dependsOn jacocoTestReport
 
     checkstyle {

--- a/check-info.sh
+++ b/check-info.sh
@@ -1,5 +1,6 @@
 #!/bin/bash
 
+JAVA_OPTS='-Djdk.tls.namedGroups="secp256k1"'
 classpathDir="./dist/conf"
 libDir="./dist/lib"
 set -- `getopt c:l: "$@"`
@@ -260,7 +261,7 @@ function check_node_version() {
 			then
 				echo "WARN: the current version of SDK does not support to check the node version, minimum version 1.4.0"
 			else
-				java -cp $libDir/*:$classpathDir/ com.webank.weid.app.AppCommand --checkversion test
+				java ${JAVA_OPTS} -cp $libDir/*:$classpathDir/ com.webank.weid.app.AppCommand --checkversion test
 			fi
 		fi
 	done
@@ -279,7 +280,7 @@ function check_node_version() {
 						echo "WARN: the current version of SDK does not support to check the node version, minimum version 1.4.0"
 					else
 						currentDir=`pwd`
-						java -cp $currentDir/dist/lib/*:$currentDir/dist/app/*:$currentDir/dist/conf/ com.webank.weid.app.AppCommand --checkversion test
+						java ${JAVA_OPTS} -cp $currentDir/dist/lib/*:$currentDir/dist/app/*:$currentDir/dist/conf/ com.webank.weid.app.AppCommand --checkversion test
 					fi
 				fi
 			done

--- a/config/checkstyle/webank_google_checks.xml
+++ b/config/checkstyle/webank_google_checks.xml
@@ -25,7 +25,7 @@
     </module>
 
     <module name="SuppressionFilter">
-        <property name="file" value="config/checkstyle/suppressions.xml"/>
+        <property name="file" value="${config_loc}/suppressions.xml"/>
         <property name="optional" value="false"/>
     </module>
     <module name="SuppressWarningsFilter"/>

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,5 @@
 org.gradle.jvmargs='-Dfile.encoding=UTF-8'
+jdkTlsNamedGroups=secp256k1
 signing.keyId=
 signing.password=
 signing.secretKeyRingFile=

--- a/src/main/java/com/webank/weid/protocol/base/CredentialPojoList.java
+++ b/src/main/java/com/webank/weid/protocol/base/CredentialPojoList.java
@@ -1,0 +1,33 @@
+/*
+ *       Copyright© (2018) WeBank Co., Ltd.
+ *
+ *       This file is part of weid-java-sdk.
+ *
+ *       weid-java-sdk is free software: you can redistribute it and/or modify
+ *       it under the terms of the GNU Lesser General Public License as published by
+ *       the Free Software Foundation, either version 3 of the License, or
+ *       (at your option) any later version.
+ *
+ *       weid-java-sdk is distributed in the hope that it will be useful,
+ *       but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *       MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *       GNU Lesser General Public License for more details.
+ *
+ *       You should have received a copy of the GNU Lesser General Public License
+ *       along with weid-java-sdk.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package com.webank.weid.protocol.base;
+
+import java.util.ArrayList;
+
+import com.webank.weid.protocol.inf.JsonSerializer;
+
+public class CredentialPojoList extends ArrayList<CredentialPojo> implements JsonSerializer {
+
+    /**
+    * the serial.
+    */
+    private static final long serialVersionUID = -6164771401868673728L;
+
+}

--- a/src/main/java/com/webank/weid/suite/transportation/pdf/impl/PdfTransportationImpl.java
+++ b/src/main/java/com/webank/weid/suite/transportation/pdf/impl/PdfTransportationImpl.java
@@ -26,7 +26,6 @@ import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.lang.reflect.Method;
-import java.security.MessageDigest;
 import java.util.ArrayList;
 import java.util.Calendar;
 import java.util.HashMap;
@@ -55,6 +54,7 @@ import com.webank.weid.constant.ErrorCode;
 import com.webank.weid.exception.WeIdBaseException;
 import com.webank.weid.protocol.base.Cpt;
 import com.webank.weid.protocol.base.CredentialPojo;
+import com.webank.weid.protocol.base.CredentialPojoList;
 import com.webank.weid.protocol.base.HashString;
 import com.webank.weid.protocol.base.PresentationE;
 import com.webank.weid.protocol.base.WeIdAuthentication;
@@ -99,8 +99,6 @@ public class PdfTransportationImpl
     private static final int FONT_SIZE_TITLE = 18;
 
     private static final int FONT_SIZE_CONTENT = 12;
-
-    private static final String MD_ALGORITHM = "SHA-256";
 
     private static final String PDF_SUFFIX = ".pdf";
 
@@ -504,6 +502,8 @@ public class PdfTransportationImpl
                 } else {
                     credentialPojoList.add(credentialPojo);
                 }
+            } else if (object instanceof CredentialPojoList) {
+                credentialPojoList = (CredentialPojoList) object;
             } else {
                 logger.error(
                         "buildPdf4DefaultTpl due to object illegal error.");
@@ -589,6 +589,8 @@ public class PdfTransportationImpl
                 } else {
                     credentialPojoList.add(credentialPojo);
                 }
+            } else if (object instanceof CredentialPojoList) {
+                credentialPojoList = (CredentialPojoList) object;
             } else {
                 logger.error(
                         "buildPdf4SpecTpl due to object illegal error.");
@@ -604,7 +606,7 @@ public class PdfTransportationImpl
             //处理credentialList，把多级claimMap转为单级map
             for (int i = 0;i < creListSize; i++) {
                 //利用cptId到链上获取CPT
-                Integer cptId = presentation.getVerifiableCredential().get(i).getCptId();
+                Integer cptId = credentialPojoList.get(i).getCptId();
                 ResponseData<Cpt> res = cptService.queryCpt(cptId);
                 Cpt cpt = res.getResult();
                 Map<String, Object> cptMap = cpt.getCptJsonSchema();
@@ -622,8 +624,8 @@ public class PdfTransportationImpl
 
 
                 //从presentation获取salt和claim
-                salt[i] = presentation.getVerifiableCredential().get(i).getSalt();
-                claim[i] = presentation.getVerifiableCredential().get(i).getClaim();
+                salt[i] = credentialPojoList.get(i).getSalt();
+                claim[i] = credentialPojoList.get(i).getClaim();
 
                 //获取claim的k-v数据
                 if (salt[i] != null && claim[i] != null) {

--- a/src/test/java/com/webank/weid/full/MockMysqlDriver.java
+++ b/src/test/java/com/webank/weid/full/MockMysqlDriver.java
@@ -10,7 +10,6 @@ import mockit.Invocation;
 import mockit.Mock;
 import mockit.MockUp;
 import org.apache.commons.collections4.CollectionUtils;
-import org.apache.commons.lang3.StringUtils;
 
 import com.webank.weid.constant.DataDriverConstant;
 import com.webank.weid.constant.ErrorCode;
@@ -27,16 +26,11 @@ public interface MockMysqlDriver {
     
     public static final Set<String> mockTableSet = new HashSet<String>();
 
-    public static final String ISMOCKKEY = "isMock";
-
     /**
      * the default method for mock mySqlDriver.
      */
     public default void mockMysqlDriver() {
-        String vlaue = (String)mockDbMap.get(ISMOCKKEY);
-        if (StringUtils.isNotBlank(vlaue)) {
-            return;
-        }
+
         if (!mockTableSet.contains("default_data")) {
             mockTableSet.add("default_data");
         }
@@ -150,6 +144,5 @@ public interface MockMysqlDriver {
                 mockTableSet.add(sqlDomain.getTableName());
             }
         };
-        mockDbMap.put(ISMOCKKEY, ISMOCKKEY);
     }
 }

--- a/src/test/java/com/webank/weid/full/TestBaseServcie.java
+++ b/src/test/java/com/webank/weid/full/TestBaseServcie.java
@@ -716,44 +716,6 @@ public abstract class TestBaseServcie extends BaseTest implements MockMysqlDrive
         Assert.assertEquals(true, responseSetAuth.getResult());
     }
 
-    protected MockUp<Future<?>> mockTimeoutFuture() {
-        return new MockUp<Future<?>>() {
-            @Mock
-            public Future<?> get(long timeout, TimeUnit unit)
-                throws TimeoutException {
-
-                throw new TimeoutException();
-            }
-        };
-    }
-
-    protected MockUp<Future<?>> mockInterruptedFuture() {
-        return new MockUp<Future<?>>() {
-            @Mock
-            public Future<?> get(long timeout, TimeUnit unit)
-                throws InterruptedException {
-
-                throw new InterruptedException();
-            }
-
-            @Mock
-            public Future<?> get()
-                throws InterruptedException {
-
-                throw new InterruptedException();
-            }
-        };
-    }
-
-    protected MockUp<Future<?>> mockReturnNullFuture() {
-        return new MockUp<Future<?>>() {
-            @Mock
-            public Future<?> get(long timeout, TimeUnit unit) {
-                return null;
-            }
-        };
-    }
-
     protected CredentialPojo copyCredentialPojo(CredentialPojo credentialPojo) {
         return CredentialUtils.copyCredential(credentialPojo);
     }

--- a/src/test/java/com/webank/weid/full/TestBaseServcie.java
+++ b/src/test/java/com/webank/weid/full/TestBaseServcie.java
@@ -28,10 +28,6 @@ import java.util.concurrent.TimeoutException;
 
 import mockit.Mock;
 import mockit.MockUp;
-import org.bcos.web3j.abi.datatypes.Address;
-import org.bcos.web3j.abi.datatypes.DynamicBytes;
-import org.bcos.web3j.abi.datatypes.generated.Bytes32;
-import org.bcos.web3j.abi.datatypes.generated.Int256;
 import org.junit.Assert;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -40,7 +36,6 @@ import com.webank.weid.BaseTest;
 import com.webank.weid.common.LogUtil;
 import com.webank.weid.common.PasswordKey;
 import com.webank.weid.constant.ErrorCode;
-import com.webank.weid.contract.v1.WeIdContract;
 import com.webank.weid.protocol.base.ClaimPolicy;
 import com.webank.weid.protocol.base.CptBaseInfo;
 import com.webank.weid.protocol.base.Credential;
@@ -755,28 +750,6 @@ public abstract class TestBaseServcie extends BaseTest implements MockMysqlDrive
             @Mock
             public Future<?> get(long timeout, TimeUnit unit) {
                 return null;
-            }
-        };
-    }
-
-    protected MockUp<WeIdContract> mockSetAttribute(MockUp<Future<?>> mockFuture) {
-        return new MockUp<WeIdContract>() {
-            @Mock
-            public Future<?> createWeId(
-                Address identity,
-                DynamicBytes auth,
-                DynamicBytes created,
-                Int256 updated) {
-                return mockFuture.getMockInstance();
-            }
-
-            @Mock
-            public Future<?> setAttribute(
-                Address identity,
-                Bytes32 key,
-                DynamicBytes value,
-                Int256 updated) {
-                return mockFuture.getMockInstance();
             }
         };
     }

--- a/src/test/java/com/webank/weid/full/credential/TestVerifyCredential.java
+++ b/src/test/java/com/webank/weid/full/credential/TestVerifyCredential.java
@@ -390,7 +390,7 @@ public class TestVerifyCredential extends TestBaseServcie {
     @Test
     public void testVerifyCredentialCase20() {
 
-        MockUp<DataToolUtils> mockTest = new MockUp<DataToolUtils>() {
+        new MockUp<DataToolUtils>() {
             @Mock
             public Sign.SignatureData simpleSignatureDeserialization(
                 byte[] serializedSignatureData) throws SignatureException {
@@ -399,8 +399,6 @@ public class TestVerifyCredential extends TestBaseServcie {
         };
         ResponseData<Boolean> response = super.verifyCredential(credential);
         LogUtil.info(logger, "verifyCredential", response);
-
-        mockTest.tearDown();
 
         Assert.assertEquals(ErrorCode.CREDENTIAL_EXCEPTION_VERIFYSIGNATURE.getCode(),
             response.getErrorCode().intValue());
@@ -538,7 +536,7 @@ public class TestVerifyCredential extends TestBaseServcie {
     @Test
     public void testVerifyCredentialCase28() {
 
-        MockUp<WeIdServiceImpl> mockTest = new MockUp<WeIdServiceImpl>() {
+        new MockUp<WeIdServiceImpl>() {
             @Mock
             public ResponseData<WeIdDocument> getWeIdDocument(String weId) {
                 ResponseData<WeIdDocument> response = new ResponseData<WeIdDocument>();
@@ -549,8 +547,6 @@ public class TestVerifyCredential extends TestBaseServcie {
 
         ResponseData<Boolean> response = super.verifyCredential(credential);
         LogUtil.info(logger, "verifyCredential", response);
-
-        mockTest.tearDown();
 
         Assert.assertEquals(ErrorCode.CREDENTIAL_WEID_DOCUMENT_ILLEGAL.getCode(),
             response.getErrorCode().intValue());

--- a/src/test/java/com/webank/weid/full/credentialpojo/TestVerifyCredentialByIssuer.java
+++ b/src/test/java/com/webank/weid/full/credentialpojo/TestVerifyCredentialByIssuer.java
@@ -409,7 +409,7 @@ public class TestVerifyCredentialByIssuer extends TestBaseServcie {
     @Test
     public void testVerifyCredentialCase20() {
 
-        MockUp<DataToolUtils> mockTest = new MockUp<DataToolUtils>() {
+        new MockUp<DataToolUtils>() {
             @Mock
             public Sign.SignatureData simpleSignatureDeserialization(
                 byte[] serializedSignatureData) throws SignatureException {
@@ -418,8 +418,6 @@ public class TestVerifyCredentialByIssuer extends TestBaseServcie {
         };
         ResponseData<Boolean> response = super.verifyCredentialPojo(credentialPojo);
         LogUtil.info(logger, "verifyCredential", response);
-
-        mockTest.tearDown();
 
         Assert.assertEquals(ErrorCode.CREDENTIAL_SIGNATURE_BROKEN.getCode(),
             response.getErrorCode().intValue());
@@ -524,7 +522,7 @@ public class TestVerifyCredentialByIssuer extends TestBaseServcie {
     @Test
     public void testVerifyCredentialCase28() {
 
-        MockUp<WeIdServiceImpl> mockTest = new MockUp<WeIdServiceImpl>() {
+        new MockUp<WeIdServiceImpl>() {
             @Mock
             public ResponseData<WeIdDocument> getWeIdDocument(String weId) {
                 ResponseData<WeIdDocument> response = new ResponseData<WeIdDocument>();
@@ -535,8 +533,6 @@ public class TestVerifyCredentialByIssuer extends TestBaseServcie {
 
         ResponseData<Boolean> response = super.verifyCredentialPojo(credentialPojo);
         LogUtil.info(logger, "verifyCredential", response);
-
-        mockTest.tearDown();
 
         Assert.assertEquals(ErrorCode.CREDENTIAL_WEID_DOCUMENT_ILLEGAL.getCode(),
             response.getErrorCode().intValue());

--- a/src/test/java/com/webank/weid/full/credentialpojo/TestVerifyCredentialByPublicKey.java
+++ b/src/test/java/com/webank/weid/full/credentialpojo/TestVerifyCredentialByPublicKey.java
@@ -450,7 +450,7 @@ public class TestVerifyCredentialByPublicKey extends TestBaseServcie {
     @Test
     public void testVerifyCredentialCase20() {
 
-        MockUp<DataToolUtils> mockTest = new MockUp<DataToolUtils>() {
+        new MockUp<DataToolUtils>() {
             @Mock
             public Sign.SignatureData simpleSignatureDeserialization(
                 byte[] serializedSignatureData) throws SignatureException {
@@ -460,8 +460,6 @@ public class TestVerifyCredentialByPublicKey extends TestBaseServcie {
         ResponseData<Boolean> response = super.verifyCredentialPojo(weIdPublicKey,
             credentialPojo);
         LogUtil.info(logger, "verifyCredential", response);
-
-        mockTest.tearDown();
 
         Assert.assertEquals(ErrorCode.CREDENTIAL_SIGNATURE_BROKEN.getCode(),
             response.getErrorCode().intValue());
@@ -571,7 +569,7 @@ public class TestVerifyCredentialByPublicKey extends TestBaseServcie {
     @Test
     public void testVerifyCredentialCase28() {
 
-        MockUp<WeIdServiceImpl> mockTest = new MockUp<WeIdServiceImpl>() {
+        new MockUp<WeIdServiceImpl>() {
             @Mock
             public ResponseData<WeIdDocument> getWeIdDocument(String weId) {
                 ResponseData<WeIdDocument> response = new ResponseData<WeIdDocument>();
@@ -582,8 +580,6 @@ public class TestVerifyCredentialByPublicKey extends TestBaseServcie {
 
         ResponseData<Boolean> response = super.verifyCredentialPojo(credentialPojo);
         LogUtil.info(logger, "verifyCredential", response);
-
-        mockTest.tearDown();
 
         Assert.assertEquals(ErrorCode.CREDENTIAL_WEID_DOCUMENT_ILLEGAL.getCode(),
             response.getErrorCode().intValue());

--- a/src/test/java/com/webank/weid/full/evidence/TestCreateEvidence.java
+++ b/src/test/java/com/webank/weid/full/evidence/TestCreateEvidence.java
@@ -46,7 +46,6 @@ import com.webank.weid.protocol.base.WeIdPrivateKey;
 import com.webank.weid.protocol.response.CreateWeIdDataResult;
 import com.webank.weid.protocol.response.ResponseData;
 import com.webank.weid.util.CredentialPojoUtils;
-import com.webank.weid.util.WeIdUtils;
 
 /**
  * Test CreateEvidence.
@@ -236,7 +235,6 @@ public class TestCreateEvidence extends TestBaseServcie {
         Credential tempCredential = copyCredential(credential);
         tempCredential.setCptId(null);
         ResponseData<String> innerResp = credentialService.getCredentialHash(tempCredential);
-        String hashValue = innerResp.getResult();
         Assert.assertEquals(
             ErrorCode.CPT_ID_ILLEGAL.getCode(),
             innerResp.getErrorCode().intValue());

--- a/src/test/java/com/webank/weid/full/evidence/TestVerifyEvidence.java
+++ b/src/test/java/com/webank/weid/full/evidence/TestVerifyEvidence.java
@@ -21,10 +21,6 @@ package com.webank.weid.full.evidence;
 
 import java.util.Map;
 
-import mockit.Mock;
-import mockit.MockUp;
-
-import org.bcos.web3j.crypto.Sign.SignatureData;
 import org.junit.Assert;
 import org.junit.Test;
 import org.slf4j.Logger;
@@ -38,7 +34,6 @@ import com.webank.weid.full.TestBaseServcie;
 import com.webank.weid.protocol.base.Credential;
 import com.webank.weid.protocol.response.CreateWeIdDataResult;
 import com.webank.weid.protocol.response.ResponseData;
-import com.webank.weid.service.impl.EvidenceServiceImpl;
 import com.webank.weid.util.DateUtils;
 
 /**
@@ -258,27 +253,5 @@ public class TestVerifyEvidence extends TestBaseServcie {
         Assert.assertEquals(responseData2.getErrorCode().intValue(),
             ErrorCode.SUCCESS.getCode());
         Assert.assertTrue(responseData2.getResult());
-    }
-
-    /**
-     * case16: mock exception.
-     */
-    @Test
-    public void testVerifyEvidenceCase16() {
-        MockUp<EvidenceServiceImpl> mockException = new MockUp<EvidenceServiceImpl>() {
-            @Mock
-            public ResponseData<Boolean> verifySignatureToSigner(String rawData,
-                String signerWeId, SignatureData signatureData) throws Exception {
-                return null;
-            }
-        };
-
-        Credential credential = copyCredential(evidenceCredential);
-        ResponseData<Boolean> responseData = evidenceService
-            .verify(credential, evidenceAddress);
-        logger.info("testVerifyEvidenceCase16 result :" + responseData);
-        Assert.assertEquals(ErrorCode.CREDENTIAL_EVIDENCE_BASE_ERROR.getCode(),
-            responseData.getErrorCode().intValue());
-        mockException.tearDown();
     }
 }

--- a/src/test/java/com/webank/weid/full/transportation/TestBaseTransportation.java
+++ b/src/test/java/com/webank/weid/full/transportation/TestBaseTransportation.java
@@ -29,6 +29,7 @@ import com.webank.weid.full.TestBaseUtil;
 import com.webank.weid.protocol.base.Challenge;
 import com.webank.weid.protocol.base.ClaimPolicy;
 import com.webank.weid.protocol.base.CredentialPojo;
+import com.webank.weid.protocol.base.CredentialPojoList;
 import com.webank.weid.protocol.base.PresentationE;
 import com.webank.weid.protocol.base.PresentationPolicyE;
 import com.webank.weid.protocol.base.WeIdAuthentication;
@@ -228,5 +229,13 @@ public abstract class TestBaseTransportation extends TestBaseServcie {
             return null;
         }
         return response.getResult();
+    }
+    
+    protected CredentialPojoList getCredentialPojoList(PresentationE presentation4MultiCpt) {
+        CredentialPojoList list = new CredentialPojoList();
+        for (CredentialPojo credentialPojo : presentation4MultiCpt.getVerifiableCredential()) {
+            list.add(credentialPojo);
+        }
+        return list;
     }
 }

--- a/src/test/java/com/webank/weid/full/transportation/TestJsonDeserialize.java
+++ b/src/test/java/com/webank/weid/full/transportation/TestJsonDeserialize.java
@@ -56,9 +56,9 @@ public class TestJsonDeserialize extends TestBaseTransportation {
 
     @Override
     public synchronized void testInit() {
+        mockMysqlDriver();
         if (presentation == null) {
             super.testInit();
-            mockMysqlDriver();
             presentation = this.getPresentationE();
             original_transString =
                 TransportationFactory.newJsonTransportation().serialize(
@@ -191,7 +191,7 @@ public class TestJsonDeserialize extends TestBaseTransportation {
                 new ProtocolProperty(EncodeType.CIPHER)
             );
 
-        MockUp<CryptServiceFactory> mockTest = new MockUp<CryptServiceFactory>() {
+        new MockUp<CryptServiceFactory>() {
             @Mock
             public CryptService getCryptService(CryptType cryptType) {
                 return new HashMap<String, CryptService>().get("key");
@@ -201,7 +201,7 @@ public class TestJsonDeserialize extends TestBaseTransportation {
         ResponseData<PresentationE> wrapperRes =
             TransportationFactory.newJsonTransportation()
                 .deserialize(weIdAuthentication, response.getResult(), PresentationE.class);
-        mockTest.tearDown();
+
         LogUtil.info(logger, "deserialize", wrapperRes);
         Assert.assertEquals(
             ErrorCode.TRANSPORTATION_ENCODE_BASE_ERROR.getCode(),
@@ -215,7 +215,7 @@ public class TestJsonDeserialize extends TestBaseTransportation {
      */
     @Test
     public void testDeserializeCase6() {
-        MockUp<EncodeType> mockTest = new MockUp<EncodeType>() {
+        new MockUp<EncodeType>() {
             @Mock
             public EncodeType getObject(String value) {
                 return null;
@@ -223,7 +223,7 @@ public class TestJsonDeserialize extends TestBaseTransportation {
         };
         ResponseData<PresentationE> wrapperRes = TransportationFactory.newJsonTransportation()
             .deserialize(original_transString, PresentationE.class);
-        mockTest.tearDown();
+
         LogUtil.info(logger, "deserialize", wrapperRes);
         Assert.assertEquals(
             ErrorCode.TRANSPORTATION_PROTOCOL_ENCODE_ERROR.getCode(),
@@ -237,7 +237,7 @@ public class TestJsonDeserialize extends TestBaseTransportation {
      */
     @Test
     public void testDeserializeCase7() {
-        MockUp<EncodeType> mockTest = new MockUp<EncodeType>() {
+        new MockUp<EncodeType>() {
             @Mock
             public EncodeType getObject(String value) {
                 return null;
@@ -249,7 +249,7 @@ public class TestJsonDeserialize extends TestBaseTransportation {
                 original_transString,
                 PresentationE.class
             );
-        mockTest.tearDown();
+
         LogUtil.info(logger, "deserialize", response);
         Assert.assertEquals(
             ErrorCode.TRANSPORTATION_PROTOCOL_ENCODE_ERROR.getCode(),

--- a/src/test/java/com/webank/weid/full/transportation/TestJsonSerialize.java
+++ b/src/test/java/com/webank/weid/full/transportation/TestJsonSerialize.java
@@ -165,7 +165,7 @@ public class TestJsonSerialize extends TestBaseTransportation {
     @Test
     public void testSerializeCase6() {
 
-        MockUp<CryptServiceFactory> mockTest = new MockUp<CryptServiceFactory>() {
+        new MockUp<CryptServiceFactory>() {
             @Mock
             public CryptService getCryptService(CryptType cryptType) {
                 return new HashMap<String, CryptService>().get("key");
@@ -175,7 +175,7 @@ public class TestJsonSerialize extends TestBaseTransportation {
         ResponseData<String> response = TransportationFactory.newJsonTransportation()
             .specify(verifier)
             .serialize(presentation, new ProtocolProperty(EncodeType.CIPHER));
-        mockTest.tearDown();
+
         LogUtil.info(logger, "serialize", response);
         Assert.assertEquals(
             ErrorCode.TRANSPORTATION_ENCODE_BASE_ERROR.getCode(),

--- a/src/test/java/com/webank/weid/full/transportation/TestJsonSpecify.java
+++ b/src/test/java/com/webank/weid/full/transportation/TestJsonSpecify.java
@@ -6,7 +6,6 @@ import java.util.List;
 import org.junit.Assert;
 import org.junit.Test;
 
-import com.webank.weid.constant.ErrorCode;
 import com.webank.weid.full.TestBaseServcie;
 import com.webank.weid.suite.api.transportation.TransportationFactory;
 import com.webank.weid.suite.api.transportation.inf.JsonTransportation;

--- a/src/test/java/com/webank/weid/full/transportation/TestPdfDeserialize.java
+++ b/src/test/java/com/webank/weid/full/transportation/TestPdfDeserialize.java
@@ -12,6 +12,7 @@ import org.slf4j.LoggerFactory;
 import com.webank.weid.common.LogUtil;
 import com.webank.weid.constant.ErrorCode;
 import com.webank.weid.protocol.base.CredentialPojo;
+import com.webank.weid.protocol.base.CredentialPojoList;
 import com.webank.weid.protocol.base.PresentationE;
 import com.webank.weid.protocol.response.ResponseData;
 import com.webank.weid.suite.api.transportation.TransportationFactory;
@@ -206,17 +207,32 @@ public class TestPdfDeserialize extends TestBaseTransportation {
 
         //1. 序列化presentation4MultiCpt为pdf文件
         ResponseData<Boolean> response = TransportationFactory
-                .newPdfTransportation()
-                .serialize(presentation4MultiCpt,
-                        new ProtocolProperty(EncodeType.ORIGINAL),
-                        weIdAuthentication,
-                        "./out.pdf");
+            .newPdfTransportation()
+            .serialize(presentation4MultiCpt,
+                new ProtocolProperty(EncodeType.ORIGINAL),
+                weIdAuthentication,
+                "./out.pdf");
         LogUtil.info(logger, "serialize", response);
         Assert.assertEquals(ErrorCode.SUCCESS.getCode(), response.getErrorCode().intValue());
         Assert.assertTrue(response.getResult());
 
+        byte[] bytesArray = getFileByte("./out.pdf");
+
+        //3. 对读取到byte[]做反序列化
+        ResponseData<PresentationE> resDeserialize = TransportationFactory
+            .newPdfTransportation()
+            .deserialize(
+                bytesArray,
+                PresentationE.class,
+                weIdAuthentication);
+        LogUtil.info(logger, "deserialize", resDeserialize);
+        Assert.assertEquals(ErrorCode.SUCCESS.getCode(), resDeserialize.getErrorCode().intValue());
+        Assert.assertEquals(presentation4MultiCpt.toJson(), resDeserialize.getResult().toJson());
+    }
+
+    private byte[] getFileByte(String filePath) {
         //2. 从pdf文件读取到byte[]
-        File file = new File("./out.pdf");
+        File file = new File(filePath);
         byte[] bytesArray = new byte[(int) file.length()];
         try {
 
@@ -226,17 +242,7 @@ public class TestPdfDeserialize extends TestBaseTransportation {
         } catch (Exception e) {
             e.printStackTrace();
         }
-
-        //3. 对读取到byte[]做反序列化
-        ResponseData<PresentationE> resDeserialize = TransportationFactory
-                .newPdfTransportation()
-                .deserialize(
-                        bytesArray,
-                        PresentationE.class,
-                        weIdAuthentication);
-        LogUtil.info(logger, "deserialize", resDeserialize);
-        Assert.assertEquals(ErrorCode.SUCCESS.getCode(), resDeserialize.getErrorCode().intValue());
-        Assert.assertEquals(presentation4MultiCpt.toJson(), resDeserialize.getResult().toJson());
+        return bytesArray;
     }
 
     /**
@@ -256,15 +262,7 @@ public class TestPdfDeserialize extends TestBaseTransportation {
         Assert.assertTrue(response.getResult());
 
         //2. 从pdf文件读取到byte[]
-        File file = new File("./test-template-complex-out.pdf");
-        byte[] bytesArray = new byte[(int) file.length()];
-        try {
-            FileInputStream fis = new FileInputStream(file);
-            fis.read(bytesArray);
-            fis.close();
-        } catch (Exception e) {
-            e.printStackTrace();
-        }
+        byte[] bytesArray = getFileByte("./test-template-complex-out.pdf");
 
         //3. 对读取到byte[]做反序列化
         ResponseData<PresentationE> resDeserialize = TransportationFactory
@@ -276,5 +274,60 @@ public class TestPdfDeserialize extends TestBaseTransportation {
         LogUtil.info(logger, "deserialize", resDeserialize);
         Assert.assertEquals(ErrorCode.SUCCESS.getCode(), resDeserialize.getErrorCode().intValue());
         Assert.assertEquals(presentation4MultiCpt.toJson(), resDeserialize.getResult().toJson());
+    }
+    
+    /**
+     * 使用原文方式构建协议数据并解析.(无模板)
+     */
+    @Test
+    public void testDeserialize_credentialList() {
+        CredentialPojoList credentialPojoList = getCredentialPojoList(presentation4MultiCpt);
+        ResponseData<byte[]> response = TransportationFactory
+            .newPdfTransportation()
+            .serialize(
+                credentialPojoList,
+                new ProtocolProperty(EncodeType.ORIGINAL),
+                weIdAuthentication);
+
+        ResponseData<CredentialPojoList> resDeserialize = TransportationFactory
+            .newPdfTransportation()
+            .deserialize(
+                response.getResult(),
+                CredentialPojoList.class,
+                weIdAuthentication);
+        LogUtil.info(logger, "deserialize", resDeserialize);
+        Assert.assertEquals(ErrorCode.SUCCESS.getCode(), resDeserialize.getErrorCode().intValue());
+        Assert.assertEquals(credentialPojoList.toJson(), resDeserialize.getResult().toJson());
+    }
+    
+    /**
+     * 使用原文方式构建协议数据并解析.(有模板)
+     */
+    @Test
+    public void testDeserializeWithTemplet_credentialList() {
+        CredentialPojoList credentialPojoList = getCredentialPojoList(presentation4MultiCpt);
+        ResponseData<Boolean> response = TransportationFactory
+            .newPdfTransportation()
+            .serializeWithTemplate(
+                credentialPojoList,
+                new ProtocolProperty(EncodeType.ORIGINAL),
+                weIdAuthentication,
+                "src/test/resources/test-template-complex.pdf",
+                "./out1.pdf"
+             );
+        LogUtil.info(logger, "serialize", response);
+        Assert.assertEquals(ErrorCode.SUCCESS.getCode(), response.getErrorCode().intValue());
+        Assert.assertTrue(response.getResult());
+        
+        byte[] bytesArray = getFileByte("./out1.pdf");
+        ResponseData<CredentialPojoList> resDeserialize = TransportationFactory
+            .newPdfTransportation()
+            .deserialize(
+                bytesArray,
+                CredentialPojoList.class,
+                weIdAuthentication);
+        LogUtil.info(logger, "deserialize", resDeserialize);
+        Assert.assertEquals(ErrorCode.SUCCESS.getCode(), resDeserialize.getErrorCode().intValue());
+        Assert.assertEquals(credentialPojoList.toJson(), resDeserialize.getResult().toJson());
     }
 }

--- a/src/test/java/com/webank/weid/full/transportation/TestPdfDeserialize.java
+++ b/src/test/java/com/webank/weid/full/transportation/TestPdfDeserialize.java
@@ -1,14 +1,9 @@
 package com.webank.weid.full.transportation;
 
-import java.io.ByteArrayOutputStream;
 import java.io.File;
 import java.io.FileInputStream;
-import java.io.OutputStream;
-import java.util.HashMap;
 import java.util.List;
 
-import mockit.Mock;
-import mockit.MockUp;
 import org.junit.Assert;
 import org.junit.Test;
 import org.slf4j.Logger;
@@ -22,9 +17,6 @@ import com.webank.weid.protocol.response.ResponseData;
 import com.webank.weid.suite.api.transportation.TransportationFactory;
 import com.webank.weid.suite.api.transportation.params.EncodeType;
 import com.webank.weid.suite.api.transportation.params.ProtocolProperty;
-import com.webank.weid.suite.crypto.CryptService;
-import com.webank.weid.suite.crypto.CryptServiceFactory;
-import com.webank.weid.suite.entity.CryptType;
 
 /**
  * test base class.
@@ -40,12 +32,12 @@ public class TestPdfDeserialize extends TestBaseTransportation {
 
     @Override
     public synchronized void testInit() {
+        mockMysqlDriver();
         if (presentation == null) {
             super.testInit();
             super.testInit4MlCpt();
             super.testInit4MultiCpt();
             super.testInitSpecTplCpt();
-            mockMysqlDriver();
             presentation = this.getPresentationE();
             presentation4MlCpt = getPresentationE4MlCpt();
             presentation4MultiCpt = getPresentationE4MultiCpt();

--- a/src/test/java/com/webank/weid/full/transportation/TestPdfSerialize.java
+++ b/src/test/java/com/webank/weid/full/transportation/TestPdfSerialize.java
@@ -49,7 +49,8 @@ public class TestPdfSerialize extends TestBaseTransportation {
             .serialize(
                 presentation,
                 new ProtocolProperty(EncodeType.ORIGINAL),
-                weIdAuthentication);
+                weIdAuthentication
+            );
         LogUtil.info(logger, "serialize", response);
         Assert.assertEquals(ErrorCode.SUCCESS.getCode(), response.getErrorCode().intValue());
         Assert.assertNotNull(response.getResult());
@@ -66,7 +67,8 @@ public class TestPdfSerialize extends TestBaseTransportation {
             .serialize(
                 presentation4MlCpt,
                 new ProtocolProperty(EncodeType.ORIGINAL),
-                weIdAuthentication);
+                weIdAuthentication
+            );
         LogUtil.info(logger, "serialize", response);
         Assert.assertEquals(ErrorCode.SUCCESS.getCode(), response.getErrorCode().intValue());
         Assert.assertNotNull(response.getResult());
@@ -82,7 +84,8 @@ public class TestPdfSerialize extends TestBaseTransportation {
             .newPdfTransportation()
             .serialize(presentation4MultiCpt,
                 new ProtocolProperty(EncodeType.ORIGINAL),
-                weIdAuthentication);
+                weIdAuthentication
+            );
         LogUtil.info(logger, "serialize", response);
         Assert.assertEquals(ErrorCode.SUCCESS.getCode(), response.getErrorCode().intValue());
         Assert.assertNotNull(response.getResult());
@@ -93,11 +96,12 @@ public class TestPdfSerialize extends TestBaseTransportation {
      */
     public void testSerializeCase31() {
         ResponseData<Boolean> response = TransportationFactory
-                .newPdfTransportation()
-                .serialize(presentation4MultiCpt,
-                        new ProtocolProperty(EncodeType.ORIGINAL),
-                        weIdAuthentication,
-                        "./");
+            .newPdfTransportation()
+            .serialize(presentation4MultiCpt,
+                new ProtocolProperty(EncodeType.ORIGINAL),
+                weIdAuthentication,
+                "./"
+            );
         LogUtil.info(logger, "serialize", response);
         Assert.assertEquals(ErrorCode.SUCCESS.getCode(), response.getErrorCode().intValue());
         Assert.assertTrue(response.getResult());
@@ -109,11 +113,12 @@ public class TestPdfSerialize extends TestBaseTransportation {
      */
     public void testSerializeCase32() {
         ResponseData<Boolean> response = TransportationFactory
-                .newPdfTransportation()
-                .serialize(presentation4MultiCpt,
-                        new ProtocolProperty(EncodeType.ORIGINAL),
-                        weIdAuthentication,
-                        "./out.pdf");
+            .newPdfTransportation()
+            .serialize(presentation4MultiCpt,
+                new ProtocolProperty(EncodeType.ORIGINAL),
+                weIdAuthentication,
+                "./out.pdf"
+            );
         LogUtil.info(logger, "serialize", response);
         Assert.assertEquals(ErrorCode.SUCCESS.getCode(), response.getErrorCode().intValue());
         Assert.assertTrue(response.getResult());
@@ -124,11 +129,12 @@ public class TestPdfSerialize extends TestBaseTransportation {
      */
     public void testSerializeCase33() {
         ResponseData<Boolean> response = TransportationFactory
-                .newPdfTransportation()
-                .serialize(presentation4MultiCpt,
-                        new ProtocolProperty(EncodeType.ORIGINAL),
-                        weIdAuthentication,
-                        "./out");
+            .newPdfTransportation()
+            .serialize(presentation4MultiCpt,
+                new ProtocolProperty(EncodeType.ORIGINAL),
+                weIdAuthentication,
+                "./out"
+            );
         LogUtil.info(logger, "serialize", response);
         Assert.assertEquals(ErrorCode.SUCCESS.getCode(), response.getErrorCode().intValue());
         Assert.assertTrue(response.getResult());
@@ -139,11 +145,12 @@ public class TestPdfSerialize extends TestBaseTransportation {
      */
     public void testSerializeCase34() {
         ResponseData<Boolean> response = TransportationFactory
-                .newPdfTransportation()
-                .serialize(presentation4MultiCpt,
-                        new ProtocolProperty(EncodeType.ORIGINAL),
-                        weIdAuthentication,
-                        "./test");
+            .newPdfTransportation()
+            .serialize(presentation4MultiCpt,
+                new ProtocolProperty(EncodeType.ORIGINAL),
+                weIdAuthentication,
+                "./test"
+            );
         LogUtil.info(logger, "serialize", response);
         Assert.assertEquals(ErrorCode.SUCCESS.getCode(), response.getErrorCode().intValue());
         Assert.assertTrue(response.getResult());
@@ -154,11 +161,12 @@ public class TestPdfSerialize extends TestBaseTransportation {
      */
     public void testSerializeCase35() {
         ResponseData<Boolean> response = TransportationFactory
-                .newPdfTransportation()
-                .serialize(presentation4MultiCpt,
-                        new ProtocolProperty(EncodeType.ORIGINAL),
-                        weIdAuthentication,
-                        "./test/out.pdf");
+            .newPdfTransportation()
+            .serialize(presentation4MultiCpt,
+                new ProtocolProperty(EncodeType.ORIGINAL),
+                weIdAuthentication,
+                "./test/out.pdf"
+            );
         LogUtil.info(logger, "serialize", response);
         Assert.assertEquals(ErrorCode.SUCCESS.getCode(), response.getErrorCode().intValue());
         Assert.assertTrue(response.getResult());
@@ -169,11 +177,12 @@ public class TestPdfSerialize extends TestBaseTransportation {
      */
     public void testSerializeCase36() {
         ResponseData<Boolean> response = TransportationFactory
-                .newPdfTransportation()
-                .serialize(presentation4MultiCpt,
-                        new ProtocolProperty(EncodeType.ORIGINAL),
-                        weIdAuthentication,
-                        "./test/test/test/test/out");
+            .newPdfTransportation()
+            .serialize(presentation4MultiCpt,
+                new ProtocolProperty(EncodeType.ORIGINAL),
+                weIdAuthentication,
+                "./test/test/test/test/out"
+            );
         LogUtil.info(logger, "serialize", response);
         Assert.assertEquals(ErrorCode.SUCCESS.getCode(), response.getErrorCode().intValue());
         Assert.assertTrue(response.getResult());
@@ -184,11 +193,12 @@ public class TestPdfSerialize extends TestBaseTransportation {
      */
     public void testSerializeCase37() {
         ResponseData<Boolean> response = TransportationFactory
-                .newPdfTransportation()
-                .serialize(presentation4MultiCpt,
-                        new ProtocolProperty(EncodeType.ORIGINAL),
-                        weIdAuthentication,
-                        "./test/test.test.test");
+            .newPdfTransportation()
+            .serialize(presentation4MultiCpt,
+                new ProtocolProperty(EncodeType.ORIGINAL),
+                weIdAuthentication,
+                "./test/test.test.test"
+            );
         LogUtil.info(logger, "serialize", response);
         Assert.assertEquals(ErrorCode.SUCCESS.getCode(), response.getErrorCode().intValue());
         Assert.assertTrue(response.getResult());
@@ -199,11 +209,12 @@ public class TestPdfSerialize extends TestBaseTransportation {
      */
     public void testSerializeCase38() {
         ResponseData<Boolean> response = TransportationFactory
-                .newPdfTransportation()
-                .serialize(presentation4MultiCpt,
-                        new ProtocolProperty(EncodeType.ORIGINAL),
-                        weIdAuthentication,
-                        "./test/te.te.te/a.b.c.pdf");
+            .newPdfTransportation()
+            .serialize(presentation4MultiCpt,
+                new ProtocolProperty(EncodeType.ORIGINAL),
+                weIdAuthentication,
+                "./test/te.te.te/a.b.c.pdf"
+            );
         LogUtil.info(logger, "serialize", response);
         Assert.assertEquals(ErrorCode.SUCCESS.getCode(), response.getErrorCode().intValue());
         Assert.assertTrue(response.getResult());
@@ -214,11 +225,12 @@ public class TestPdfSerialize extends TestBaseTransportation {
      */
     public void testSerializeCase39() {
         ResponseData<Boolean> response = TransportationFactory
-                .newPdfTransportation()
-                .serialize(presentation4MultiCpt,
-                        new ProtocolProperty(EncodeType.ORIGINAL),
-                        weIdAuthentication,
-                        "./test/test.test.test/a.b.c.pdf");
+            .newPdfTransportation()
+            .serialize(presentation4MultiCpt,
+                new ProtocolProperty(EncodeType.ORIGINAL),
+                weIdAuthentication,
+                "./test/test.test.test/a.b.c.pdf"
+            );
         LogUtil.info(logger, "serialize", response);
         Assert.assertEquals(ErrorCode.SUCCESS.getCode(), response.getErrorCode().intValue());
         Assert.assertTrue(response.getResult());
@@ -229,11 +241,12 @@ public class TestPdfSerialize extends TestBaseTransportation {
      */
     public void testSerializeCase310() {
         ResponseData<Boolean> response = TransportationFactory
-                .newPdfTransportation()
-                .serialize(presentation4MultiCpt,
-                        new ProtocolProperty(EncodeType.ORIGINAL),
-                        weIdAuthentication,
-                        "");
+            .newPdfTransportation()
+            .serialize(presentation4MultiCpt,
+                new ProtocolProperty(EncodeType.ORIGINAL),
+                weIdAuthentication,
+                ""
+            );
         LogUtil.info(logger, "serialize", response);
         Assert.assertEquals(ErrorCode.ILLEGAL_INPUT.getCode(), response.getErrorCode().intValue());
         Assert.assertTrue(!response.getResult());
@@ -250,7 +263,8 @@ public class TestPdfSerialize extends TestBaseTransportation {
             .serialize(
                 presentation,
                 new ProtocolProperty(EncodeType.CIPHER),
-                weIdAuthentication);
+                weIdAuthentication
+            );
         LogUtil.info(logger, "serialize", response);
         Assert.assertEquals(ErrorCode.SUCCESS.getCode(), response.getErrorCode().intValue());
         Assert.assertNotNull(response.getResult());
@@ -265,7 +279,8 @@ public class TestPdfSerialize extends TestBaseTransportation {
             .newPdfTransportation()
             .serialize(presentation,
                 new ProtocolProperty(null),
-                weIdAuthentication);
+                weIdAuthentication
+            );
         LogUtil.info(logger, "serialize", response);
         Assert.assertEquals(
             ErrorCode.TRANSPORTATION_PROTOCOL_ENCODE_ERROR.getCode(),
@@ -284,7 +299,8 @@ public class TestPdfSerialize extends TestBaseTransportation {
             .serialize(
                 presentation,
                 null,
-                weIdAuthentication);
+                weIdAuthentication
+            );
         LogUtil.info(logger, "serialize", response);
         Assert.assertEquals(
             ErrorCode.TRANSPORTATION_PROTOCOL_PROPERTY_ERROR.getCode(),
@@ -303,7 +319,8 @@ public class TestPdfSerialize extends TestBaseTransportation {
             .serialize(
                 presentation,
                 new ProtocolProperty(EncodeType.ORIGINAL),
-                weIdAuthentication);
+                weIdAuthentication
+            );
         LogUtil.info(logger, "serialize", response);
         Assert.assertEquals(
             ErrorCode.TRANSPORTATION_PROTOCOL_DATA_INVALID.getCode(),
@@ -321,7 +338,8 @@ public class TestPdfSerialize extends TestBaseTransportation {
             .serialize(
                 presentation,
                 new ProtocolProperty(EncodeType.ORIGINAL),
-                null);
+                null
+            );
         LogUtil.info(logger, "serialize", response);
         Assert.assertEquals(
             ErrorCode.WEID_AUTHORITY_INVALID.getCode(),
@@ -341,7 +359,7 @@ public class TestPdfSerialize extends TestBaseTransportation {
                 new ProtocolProperty(EncodeType.ORIGINAL),
                 weIdAuthentication,
                 "src/test/resources/test-template.pdf"
-                );
+            );
         LogUtil.info(logger, "serialize", response);
         Assert.assertEquals(
             ErrorCode.SUCCESS.getCode(),
@@ -354,14 +372,14 @@ public class TestPdfSerialize extends TestBaseTransportation {
      */
     public void testSerializeCase91() {
         ResponseData<Boolean> response = TransportationFactory
-                .newPdfTransportation()
-                .serializeWithTemplate(
-                        presentation4SpecTpl,
-                        new ProtocolProperty(EncodeType.ORIGINAL),
-                        weIdAuthentication,
-                        "src/test/resources/test-template.pdf",
-                        "./"
-                );
+            .newPdfTransportation()
+            .serializeWithTemplate(
+                presentation4SpecTpl,
+                new ProtocolProperty(EncodeType.ORIGINAL),
+                weIdAuthentication,
+                "src/test/resources/test-template.pdf",
+                "./"
+            );
         LogUtil.info(logger, "serialize", response);
         Assert.assertEquals(
                 ErrorCode.SUCCESS.getCode(),
@@ -375,13 +393,13 @@ public class TestPdfSerialize extends TestBaseTransportation {
     @Test
     public void testSerializeCase10() {
         ResponseData<byte[]> response = TransportationFactory
-                .newPdfTransportation()
-                .serializeWithTemplate(
-                        presentation4MultiCpt,
-                        new ProtocolProperty(EncodeType.ORIGINAL),
-                        weIdAuthentication,
-                        "src/test/resources/test-template-complex.pdf"
-                );
+            .newPdfTransportation()
+            .serializeWithTemplate(
+                presentation4MultiCpt,
+                new ProtocolProperty(EncodeType.ORIGINAL),
+                weIdAuthentication,
+                "src/test/resources/test-template-complex.pdf"
+            );
         LogUtil.info(logger, "serialize", response);
         Assert.assertEquals(
                 ErrorCode.SUCCESS.getCode(),
@@ -394,14 +412,14 @@ public class TestPdfSerialize extends TestBaseTransportation {
      */
     public void testSerializeCase101() {
         ResponseData<Boolean> response = TransportationFactory
-                .newPdfTransportation()
-                .serializeWithTemplate(
-                        presentation4MultiCpt,
-                        new ProtocolProperty(EncodeType.ORIGINAL),
-                        weIdAuthentication,
-                        "src/test/resources/test-template-complex.pdf",
-                        "./test-template-complex-out.pdf"
-                );
+            .newPdfTransportation()
+            .serializeWithTemplate(
+                presentation4MultiCpt,
+                new ProtocolProperty(EncodeType.ORIGINAL),
+                weIdAuthentication,
+                "src/test/resources/test-template-complex.pdf",
+                "./test-template-complex-out.pdf"
+            );
         LogUtil.info(logger, "serialize", response);
         Assert.assertEquals(
                 ErrorCode.SUCCESS.getCode(),
@@ -421,7 +439,7 @@ public class TestPdfSerialize extends TestBaseTransportation {
                 new ProtocolProperty(EncodeType.ORIGINAL),
                 weIdAuthentication,
                 ""
-                );
+            );
         LogUtil.info(logger, "serialize", response);
         Assert.assertEquals(
             ErrorCode.ILLEGAL_INPUT.getCode(),
@@ -441,7 +459,7 @@ public class TestPdfSerialize extends TestBaseTransportation {
                 new ProtocolProperty(EncodeType.ORIGINAL),
                 weIdAuthentication,
                 "illegal"
-                );
+            );
         LogUtil.info(logger, "serialize", response);
         Assert.assertEquals(
             ErrorCode.ILLEGAL_INPUT.getCode(), response.getErrorCode().intValue());
@@ -454,17 +472,55 @@ public class TestPdfSerialize extends TestBaseTransportation {
     @Test
     public void testSerializeCase13() {
         ResponseData<byte[]> response = TransportationFactory
-                .newPdfTransportation()
-                .serializeWithTemplate(
-                        presentation4SpecTpl,
-                        new ProtocolProperty(EncodeType.ORIGINAL),
-                        weIdAuthentication,
-                        "src/test/resources/test-template-complex.pdf"
-                );
+            .newPdfTransportation()
+            .serializeWithTemplate(
+                presentation4SpecTpl,
+                new ProtocolProperty(EncodeType.ORIGINAL),
+                weIdAuthentication,
+                "src/test/resources/test-template-complex.pdf"
+            );
         LogUtil.info(logger, "serialize", response);
         Assert.assertEquals(
                 ErrorCode.TRANSPORTATION_PDF_TRANSFER_ERROR.getCode(),
                 response.getErrorCode().intValue());
         Assert.assertNull(response.getResult());
+    }
+    
+    /**
+     *将credentialList序列化成pdf(指定模板).
+     */
+    @Test
+    public void testSerializeWithTemplate_credentialList() {
+        ResponseData<Boolean> response = TransportationFactory
+            .newPdfTransportation()
+            .serializeWithTemplate(
+                getCredentialPojoList(presentation4MultiCpt),
+                new ProtocolProperty(EncodeType.ORIGINAL),
+                weIdAuthentication,
+                "src/test/resources/test-template-complex.pdf",
+                "./"
+            );
+        LogUtil.info(logger, "serialize", response);
+        Assert.assertEquals(
+            ErrorCode.SUCCESS.getCode(),
+            response.getErrorCode().intValue());
+        Assert.assertTrue(response.getResult());
+    }
+    
+    /**
+     *将credentialList序列化成pdf(不指定模板).
+     */
+    @Test
+    public void testSerialize_credentialList() {
+        ResponseData<byte[]> response = TransportationFactory
+            .newPdfTransportation()
+            .serialize(
+                getCredentialPojoList(presentation4MultiCpt),
+                new ProtocolProperty(EncodeType.ORIGINAL),
+                weIdAuthentication
+            );
+        LogUtil.info(logger, "serialize", response);
+        Assert.assertEquals(ErrorCode.SUCCESS.getCode(), response.getErrorCode().intValue());
+        Assert.assertNotNull(response.getResult());
     }
 }

--- a/src/test/java/com/webank/weid/full/transportation/TestPdfSerialize.java
+++ b/src/test/java/com/webank/weid/full/transportation/TestPdfSerialize.java
@@ -1,7 +1,5 @@
 package com.webank.weid.full.transportation;
 
-import java.io.OutputStream;
-
 import org.junit.Assert;
 import org.junit.Test;
 import org.slf4j.Logger;

--- a/src/test/java/com/webank/weid/full/transportation/TestQrCodeDeserialize.java
+++ b/src/test/java/com/webank/weid/full/transportation/TestQrCodeDeserialize.java
@@ -19,7 +19,6 @@
 
 package com.webank.weid.full.transportation;
 
-import java.lang.reflect.Method;
 import java.util.HashMap;
 
 import mockit.Mock;
@@ -236,7 +235,7 @@ public class TestQrCodeDeserialize extends TestBaseTransportation {
                 new ProtocolProperty(EncodeType.CIPHER)
             );
 
-        MockUp<CryptServiceFactory> mockTest = new MockUp<CryptServiceFactory>() {
+        new MockUp<CryptServiceFactory>() {
             @Mock
             public CryptService getCryptService(CryptType cryptType) {
                 return new HashMap<String, CryptService>().get("key");
@@ -246,7 +245,7 @@ public class TestQrCodeDeserialize extends TestBaseTransportation {
         ResponseData<PresentationE> wrapperRes =
             TransportationFactory.newQrCodeTransportation()
                 .deserialize(weIdAuthentication, response.getResult(), PresentationE.class);
-        mockTest.tearDown();
+
         LogUtil.info(logger, "deserialize", wrapperRes);
         Assert.assertEquals(
             ErrorCode.TRANSPORTATION_ENCODE_BASE_ERROR.getCode(),
@@ -260,7 +259,7 @@ public class TestQrCodeDeserialize extends TestBaseTransportation {
      */
     @Test
     public void testDeserializeCase11() {
-        MockUp<QrCodeBaseData> mockTest = new MockUp<QrCodeBaseData>() {
+        new MockUp<QrCodeBaseData>() {
             @Mock
             public QrCodeBaseData newInstance(Class<?> cls) throws ReflectiveOperationException {
                 return new HashMap<String, QrCodeBaseData>().get("key");
@@ -270,7 +269,7 @@ public class TestQrCodeDeserialize extends TestBaseTransportation {
         ResponseData<PresentationE> wrapperRes =
             TransportationFactory.newQrCodeTransportation()
                 .deserialize(original_transString, PresentationE.class);
-        mockTest.tearDown();
+
         LogUtil.info(logger, "deserialize", wrapperRes);
         Assert.assertEquals(
             ErrorCode.UNKNOW_ERROR.getCode(),
@@ -280,35 +279,7 @@ public class TestQrCodeDeserialize extends TestBaseTransportation {
     }
 
     /**
-     * mock异常情况.
-     */
-    @Test
-    public void testSerializeCase11() {
-
-        MockUp<QrCodeBaseData> mockTest = new MockUp<QrCodeBaseData>() {
-            @Mock
-            public Method getGetterMethod(
-                Class<?> cls,
-                String fieldName
-            ) throws NoSuchMethodException {
-                return cls.getMethod("get" + fieldName, new Class[0]);
-            }
-        };
-
-        ResponseData<PresentationE> wrapperRes =
-            TransportationFactory.newQrCodeTransportation()
-                .deserialize(original_transString, PresentationE.class);
-        mockTest.tearDown();
-        LogUtil.info(logger, "deserialize", wrapperRes);
-        Assert.assertEquals(
-            ErrorCode.BASE_ERROR.getCode(),
-            wrapperRes.getErrorCode().intValue()
-        );
-        Assert.assertNull(wrapperRes.getResult());
-    }
-
-    /**
-     * 改变协议指定段数据.
+          * 改变协议指定段数据.
      *
      * @param transString 原协议数据
      * @param index 段位

--- a/src/test/java/com/webank/weid/full/transportation/TestQrCodeSerialize.java
+++ b/src/test/java/com/webank/weid/full/transportation/TestQrCodeSerialize.java
@@ -19,7 +19,6 @@
 
 package com.webank.weid.full.transportation;
 
-import java.lang.reflect.Method;
 import java.util.HashMap;
 
 import mockit.Mock;
@@ -211,7 +210,7 @@ public class TestQrCodeSerialize extends TestBaseTransportation {
     @Test
     public void testSerializeCase7() {
 
-        MockUp<CryptServiceFactory> mockTest = new MockUp<CryptServiceFactory>() {
+        new MockUp<CryptServiceFactory>() {
             @Mock
             public CryptService getCryptService(CryptType cryptType) {
                 return new HashMap<String, CryptService>().get("key");
@@ -221,7 +220,7 @@ public class TestQrCodeSerialize extends TestBaseTransportation {
         ResponseData<String> response =
             TransportationFactory.newQrCodeTransportation().specify(verifier)
                 .serialize(presentation, new ProtocolProperty(EncodeType.CIPHER));
-        mockTest.tearDown();
+
         LogUtil.info(logger, "serialize", response);
         Assert.assertEquals(
             ErrorCode.TRANSPORTATION_ENCODE_BASE_ERROR.getCode(),
@@ -236,7 +235,7 @@ public class TestQrCodeSerialize extends TestBaseTransportation {
     @Test
     public void testSerializeCase8() {
 
-        MockUp<QrCodeBaseData> mockTest = new MockUp<QrCodeBaseData>() {
+        new MockUp<QrCodeBaseData>() {
             @Mock
             public QrCodeBaseData newInstance(Class<?> cls) throws ReflectiveOperationException {
                 return new HashMap<String, QrCodeBaseData>().get("key");
@@ -246,37 +245,9 @@ public class TestQrCodeSerialize extends TestBaseTransportation {
         ResponseData<String> response =
             TransportationFactory.newQrCodeTransportation().specify(verifier)
                 .serialize(presentation, new ProtocolProperty(EncodeType.CIPHER));
-        mockTest.tearDown();
+
         LogUtil.info(logger, "serialize", response);
         Assert.assertEquals(ErrorCode.UNKNOW_ERROR.getCode(), response.getErrorCode().intValue());
-        Assert.assertEquals(StringUtils.EMPTY, response.getResult());
-    }
-
-    /**
-     * mock异常情况.
-     */
-    @Test
-    public void testSerializeCase9() {
-
-        MockUp<QrCodeBaseData> mockTest = new MockUp<QrCodeBaseData>() {
-            @Mock
-            public Method getGetterMethod(
-                Class<?> cls,
-                String fieldName
-            ) throws NoSuchMethodException {
-                return cls.getMethod("get" + fieldName, new Class[0]);
-            }
-        };
-
-        ResponseData<String> response =
-            TransportationFactory.newQrCodeTransportation().specify(verifier)
-                .serialize(presentation, new ProtocolProperty(EncodeType.CIPHER));
-        mockTest.tearDown();
-        LogUtil.info(logger, "serialize", response);
-        Assert.assertEquals(
-            ErrorCode.BASE_ERROR.getCode(),
-            response.getErrorCode().intValue()
-        );
         Assert.assertEquals(StringUtils.EMPTY, response.getResult());
     }
 }

--- a/src/test/java/com/webank/weid/full/weid/TestCreateWeId1.java
+++ b/src/test/java/com/webank/weid/full/weid/TestCreateWeId1.java
@@ -81,7 +81,7 @@ public class TestCreateWeId1 extends TestBaseServcie {
     @Test
     public void testCreateWeId_createEcKeyPairErr() {
 
-        MockUp<Keys> mockTest = new MockUp<Keys>() {
+        new MockUp<Keys>() {
             @Mock
             public ECKeyPair createEcKeyPair()
                 throws NoSuchProviderException {
@@ -93,7 +93,6 @@ public class TestCreateWeId1 extends TestBaseServcie {
         ResponseData<CreateWeIdDataResult> response = weIdService.createWeId();
         LogUtil.info(logger, "createWeId", response);
 
-        mockTest.tearDown();
 
         Assert.assertEquals(ErrorCode.WEID_KEYPAIR_CREATE_FAILED.getCode(),
             response.getErrorCode().intValue());

--- a/src/test/java/com/webank/weid/full/weid/TestCreateWeId2.java
+++ b/src/test/java/com/webank/weid/full/weid/TestCreateWeId2.java
@@ -402,7 +402,7 @@ public class TestCreateWeId2 extends TestBaseServcie {
 
         CreateWeIdArgs createWeIdArgs = TestBaseUtil.buildCreateWeIdArgs();
 
-        MockUp<BaseEngine> mockTest = new MockUp<BaseEngine>() {
+        new MockUp<BaseEngine>() {
             @Mock
             public <T> T reloadContract(String contractAddress, String privateKey, Class<T> cls)
                 throws PrivateKeyIllegalException {
@@ -413,8 +413,6 @@ public class TestCreateWeId2 extends TestBaseServcie {
 
         ResponseData<String> response = weIdService.createWeId(createWeIdArgs);
         LogUtil.info(logger, "createWeId", response);
-
-        mockTest.tearDown();
 
         Assert.assertEquals(ErrorCode.WEID_PRIVATEKEY_INVALID.getCode(),
             response.getErrorCode().intValue());

--- a/src/test/java/com/webank/weid/full/weid/TestGetWeIdDocumentJson.java
+++ b/src/test/java/com/webank/weid/full/weid/TestGetWeIdDocumentJson.java
@@ -243,7 +243,7 @@ public class TestGetWeIdDocumentJson extends TestBaseServcie {
     @Test
     public void testGetWeIdDocumentJsonCase6() {
 
-        MockUp<ObjectMapper> mockTest = new MockUp<ObjectMapper>() {
+        new MockUp<ObjectMapper>() {
             @Mock
             public ObjectWriter writerWithDefaultPrettyPrinter() {
                 return null;
@@ -253,8 +253,6 @@ public class TestGetWeIdDocumentJson extends TestBaseServcie {
         ResponseData<String> weIdDoc =
             weIdService.getWeIdDocumentJson(createWeIdForGetJson.getWeId());
         LogUtil.info(logger, "getWeIdDocumentJson", weIdDoc);
-
-        mockTest.tearDown();
 
         Assert.assertEquals(ErrorCode.SUCCESS.getCode(), weIdDoc.getErrorCode().intValue());
         Assert.assertEquals(StringUtils.EMPTY, weIdDoc.getResult());


### PR DESCRIPTION
## Summary
1. 升级jackson到2.10.0
2. 支持jdk各版本的安装并运行测试( 添加JVM参数)
3. 升级jacoco版本
4. 升级mockit版本并适配测试用例
5. 新增将CredentialPojo集合序列化成PdfTransportation以及测试用例和问题修复