### PR TITLE
* Fix font file corruption issue.

### DIFF
--- a/src/main/java/com/webank/weid/suite/transportation/pdf/impl/PdfTransportationImpl.java
+++ b/src/main/java/com/webank/weid/suite/transportation/pdf/impl/PdfTransportationImpl.java
@@ -111,6 +111,8 @@ public class PdfTransportationImpl
     private static final String PDF_ATTRIBUTE_VERSION = "version";
     private static final String PDF_ATTRIBUTE_TEMPLATE_ID = "pdfTemplateId";
 
+    private static final int FONT_SIZE = 18288912;
+
     private static CptService cptService = new CptServiceImpl();
 
     /**
@@ -651,6 +653,10 @@ public class PdfTransportationImpl
                 .getClass()
                 .getClassLoader()
                 .getResourceAsStream("NotoSansCJKtc-Regular.ttf");
+            if (is.available() != FONT_SIZE) {
+                logger.error("buildPdf4SpecTpl due to font file is corrupted error.");
+                throw new WeIdBaseException(ErrorCode.TRANSPORTATION_PDF_TRANSFER_ERROR);
+            }
             TTFParser parser = new TTFParser();
             if (is == null) {
                 logger.error(
@@ -1224,6 +1230,10 @@ public class PdfTransportationImpl
             InputStream is = this.getClass()
                 .getClassLoader()
                 .getResourceAsStream("NotoSansCJKtc-Regular.ttf");
+            if (is.available() != FONT_SIZE) {
+                logger.error("buildPdf4SpecTpl due to font file is corrupted error.");
+                throw new WeIdBaseException(ErrorCode.TRANSPORTATION_PDF_TRANSFER_ERROR);
+            }
             logger.error("InputStream:" + is.available());
             PDType0Font fontChinese = PDType0Font.load(document, is);
 


### PR DESCRIPTION
1. 因为项目中的字体文件是固定大小的，所以通过读取字体文件的大小来判断拉取项目文件时字体文件是否有损坏。
