### PR TITLE
* add code for decimalKeyToBase64

### DIFF
--- a/src/main/java/com/webank/weid/service/impl/CredentialPojoServiceImpl.java
+++ b/src/main/java/com/webank/weid/service/impl/CredentialPojoServiceImpl.java
@@ -940,8 +940,7 @@ public class CredentialPojoServiceImpl implements CredentialPojoService {
             ErrorCode verifyErrorCode = DataToolUtils
                 .verifySecp256k1SignatureFromWeId(rawData, credential.getSignature(), weIdDocument);
             if (verifyErrorCode.getCode() != ErrorCode.SUCCESS.getCode()) {
-                return new ResponseData<Boolean>(false,
-                    ErrorCode.getTypeByErrorCode(innerResponseData.getErrorCode()));
+                return new ResponseData<Boolean>(false, verifyErrorCode);
             }
             return new ResponseData<Boolean>(true, ErrorCode.SUCCESS);
 

--- a/src/main/java/com/webank/weid/suite/api/crypto/params/KeyGenerator.java
+++ b/src/main/java/com/webank/weid/suite/api/crypto/params/KeyGenerator.java
@@ -19,6 +19,7 @@
 
 package com.webank.weid.suite.api.crypto.params;
 
+import java.math.BigInteger;
 import java.nio.charset.StandardCharsets;
 import java.security.KeyPair;
 import java.security.KeyPairGenerator;
@@ -26,6 +27,8 @@ import java.security.NoSuchAlgorithmException;
 import java.security.SecureRandom;
 
 import org.apache.commons.codec.binary.Base64;
+import org.bcos.web3j.utils.Numeric;
+import org.fisco.bcos.web3j.crypto.Keys;
 
 import com.webank.weid.util.DataToolUtils;
 
@@ -80,5 +83,32 @@ public class KeyGenerator {
         key.setPrivavteKey(pri);
         key.setPublicKey(pub);
         return key;
+    }
+    
+    /**
+     * 将WeId生成的10进制密钥转换成可以加解密的Base64密钥.
+     * 该方法根据密钥字节长度自动判断是公钥还私钥
+     * @param decimalKey 10进制的数字密钥
+     * @return 返回补位后的base64密钥
+     */
+    public static String decimalKeyToBase64(String decimalKey) {
+        BigInteger bigInt = new BigInteger(decimalKey, 10);
+        int keySize = Keys.PUBLIC_KEY_LENGTH_IN_HEX;
+        //公钥字节长度为63, 64, 65
+        //私钥的字节长度32, 33, 30, 31
+        if (bigInt.toByteArray().length < 50) {
+            keySize = Keys.PRIVATE_KEY_LENGTH_IN_HEX;
+        }
+        String hex = Numeric.toHexStringNoPrefixZeroPadded(bigInt, keySize);
+        return Base64.encodeBase64String(Numeric.hexStringToByteArray(hex));
+    }
+    
+    /**
+     * 将Base64类型的密钥转换成10进制的数字密钥.
+     * @param base64Key Base64类型密钥
+     * @return 返回10进制的数字密钥
+     */
+    public static String base64KeyTodecimal(String base64Key) {
+        return Numeric.toBigInt(Base64.decodeBase64(base64Key)).toString();
     }
 }

--- a/src/main/java/com/webank/weid/suite/api/crypto/params/KeyGenerator.java
+++ b/src/main/java/com/webank/weid/suite/api/crypto/params/KeyGenerator.java
@@ -27,6 +27,7 @@ import java.security.NoSuchAlgorithmException;
 import java.security.SecureRandom;
 
 import org.apache.commons.codec.binary.Base64;
+import org.apache.commons.lang3.StringUtils;
 import org.bcos.web3j.utils.Numeric;
 import org.fisco.bcos.web3j.crypto.Keys;
 
@@ -92,6 +93,9 @@ public class KeyGenerator {
      * @return 返回补位后的base64密钥
      */
     public static String decimalKeyToBase64(String decimalKey) {
+        if (!StringUtils.isNumeric(decimalKey)) {
+            return StringUtils.EMPTY;
+        }
         BigInteger bigInt = new BigInteger(decimalKey, 10);
         int keySize = Keys.PUBLIC_KEY_LENGTH_IN_HEX;
         //公钥字节长度为63, 64, 65
@@ -109,6 +113,9 @@ public class KeyGenerator {
      * @return 返回10进制的数字密钥
      */
     public static String base64KeyTodecimal(String base64Key) {
+        if (!DataToolUtils.isValidBase64String(base64Key)) {
+            return StringUtils.EMPTY; 
+        }
         return Numeric.toBigInt(Base64.decodeBase64(base64Key)).toString();
     }
 }

--- a/src/main/java/com/webank/weid/suite/crypto/EciesCryptoService.java
+++ b/src/main/java/com/webank/weid/suite/crypto/EciesCryptoService.java
@@ -39,20 +39,24 @@ import com.webank.weid.suite.api.crypto.inf.CryptoService;
 import com.webank.weid.util.DataToolUtils;
 
 public class EciesCryptoService implements CryptoService {
-    
+
     private static final Logger logger = LoggerFactory.getLogger(EciesCryptoService.class);
-    
+
     @Override
     public String encrypt(String content, String key) throws EncodeSuiteException {
         logger.info("begin encrypt by ecies.");
         checkForEncrypt(content, key);
         String data = Numeric.toHexStringNoPrefix(content.getBytes(StandardCharsets.UTF_8));
         String pubValue = null;
-        if (isNumeric(key)) {
+        if (StringUtils.isNumeric(key)) {
             //如果为10进制数字
             BigInteger bigInt = new BigInteger(key);
             pubValue = Numeric.toHexStringNoPrefixZeroPadded(bigInt, Keys.PUBLIC_KEY_LENGTH_IN_HEX);
         } else {
+            if (!DataToolUtils.isValidBase64String(key)) {
+                String errorMessage = "input publicKey is not a valid Base64 string.";
+                throw new EncodeSuiteException(ErrorCode.ILLEGAL_INPUT, errorMessage);
+            }
             pubValue = Numeric.toHexStringNoPrefix(Base64.decodeBase64(key));
         }
         EciesResult result =  NativeInterface.eciesEncrypt(pubValue, data); // 加密
@@ -67,45 +71,34 @@ public class EciesCryptoService implements CryptoService {
         }
         throw new EncodeSuiteException(ErrorCode.UNKNOW_ERROR);
     }
-    
+
     private void checkForEncrypt(String content, String key) {
-        // 入参非空检查
-        String errorMessage = null;
-        if (StringUtils.isEmpty(content)) {
-            errorMessage = "input content is null.";
-            throw new EncodeSuiteException(ErrorCode.ILLEGAL_INPUT, errorMessage);
-        }
+        check(content, key);
         // 检查content是否为utf-8
         boolean isUtf8 = Charset.forName(StandardCharsets.UTF_8.toString())
             .newEncoder().canEncode(content);
         if (!isUtf8) {
-            errorMessage = "input content is not utf-8.";
-            throw new EncodeSuiteException(ErrorCode.ILLEGAL_INPUT, errorMessage);
-        }
-        // 入参非空检查
-        if (StringUtils.isEmpty(key)) {
-            errorMessage = "input publicKey is null.";
-            throw new EncodeSuiteException(ErrorCode.ILLEGAL_INPUT, errorMessage);
-        }
-        // 检查publicKey是否为标准base64格式
-        if (!DataToolUtils.isValidBase64String(key) && !isNumeric(key)) {
-            errorMessage = "input publicKey is not a valid Base64 string or Digit string.";
+            String errorMessage = "input content is not utf-8.";
             throw new EncodeSuiteException(ErrorCode.ILLEGAL_INPUT, errorMessage);
         }
     }
-    
+
     @Override
     public String decrypt(String content, String key) throws EncodeSuiteException {
         logger.info("begin decrypt by ecies.");
         checkForDecrypt(content, key);
         String data = Numeric.toHexStringNoPrefix(Base64.decodeBase64(content));
         String priValue = null;
-        if (isNumeric(key)) {
+        if (StringUtils.isNumeric(key)) {
             //如果为10进制数字
             BigInteger bigInt = new BigInteger(key);
             priValue = Numeric.toHexStringNoPrefixZeroPadded(
                 bigInt, Keys.PRIVATE_KEY_LENGTH_IN_HEX);
         } else {
+            if (!DataToolUtils.isValidBase64String(key)) {
+                String errorMessage = "input privateKey is not a valid Base64 string.";
+                throw new EncodeSuiteException(ErrorCode.ILLEGAL_INPUT, errorMessage);
+            }
             priValue = Numeric.toHexStringNoPrefix(Base64.decodeBase64(key));
         }
         EciesResult deResult =  NativeInterface.eciesDecrypt(priValue, data);
@@ -120,36 +113,27 @@ public class EciesCryptoService implements CryptoService {
         }
         throw new EncodeSuiteException(ErrorCode.UNKNOW_ERROR);
     }
-    
+
     private void checkForDecrypt(String content, String key) {
+        check(content, key);
+        // 检查content是否为标准base64格式
+        if (!DataToolUtils.isValidBase64String(content)) {
+            String errorMessage = "input content is not a valid Base64 string.";
+            throw new EncodeSuiteException(ErrorCode.ILLEGAL_INPUT, errorMessage);
+        }
+    }
+
+    private static void check(String content, String key) {
         // 入参非空检查
         String errorMessage = null;
         if (StringUtils.isEmpty(content)) {
             errorMessage = "input content is null.";
             throw new EncodeSuiteException(ErrorCode.ILLEGAL_INPUT, errorMessage);
         }
-        // 检查content是否为标准base64格式
-        if (!DataToolUtils.isValidBase64String(content)) {
-            errorMessage = "input content is not a valid Base64 string.";
-            throw new EncodeSuiteException(ErrorCode.ILLEGAL_INPUT, errorMessage);
-        }
         // 入参非空检查
         if (StringUtils.isEmpty(key)) {
-            errorMessage = "input privateKey is null.";
+            errorMessage = "input key is null.";
             throw new EncodeSuiteException(ErrorCode.ILLEGAL_INPUT, errorMessage);
         }
-        // 检查privateKey是否为标准base64格式
-        if (!DataToolUtils.isValidBase64String(key) && !isNumeric(key)) {
-            errorMessage = "input privateKey is not a valid Base64 string or Digit string.";
-            throw new EncodeSuiteException(ErrorCode.ILLEGAL_INPUT, errorMessage);
-        } 
-    }
-    
-    private static boolean isNumeric(final String str) {
-        // null or empty
-        if (str == null || str.length() == 0) {
-            return false;
-        }
-        return str.chars().allMatch(Character::isDigit);
     }
 }

--- a/src/main/java/com/webank/weid/suite/crypto/EciesCryptoService.java
+++ b/src/main/java/com/webank/weid/suite/crypto/EciesCryptoService.java
@@ -47,9 +47,14 @@ public class EciesCryptoService implements CryptoService {
         logger.info("begin encrypt by ecies.");
         checkForEncrypt(content, key);
         String data = Numeric.toHexStringNoPrefix(content.getBytes(StandardCharsets.UTF_8));
-        BigInteger pub = new BigInteger(Base64.decodeBase64(key));
-        String pubValue = Numeric.toHexStringNoPrefixZeroPadded(
-            pub, Keys.PUBLIC_KEY_LENGTH_IN_HEX);
+        String pubValue = null;
+        if (isNumeric(key)) {
+            //如果为10进制数字
+            BigInteger bigInt = new BigInteger(key);
+            pubValue = Numeric.toHexStringNoPrefixZeroPadded(bigInt, Keys.PUBLIC_KEY_LENGTH_IN_HEX);
+        } else {
+            pubValue = Numeric.toHexStringNoPrefix(Base64.decodeBase64(key));
+        }
         EciesResult result =  NativeInterface.eciesEncrypt(pubValue, data); // 加密
         if (result != null) {
             if (StringUtils.isBlank(result.wedprErrorMessage)) {
@@ -83,8 +88,8 @@ public class EciesCryptoService implements CryptoService {
             throw new EncodeSuiteException(ErrorCode.ILLEGAL_INPUT, errorMessage);
         }
         // 检查publicKey是否为标准base64格式
-        if (!DataToolUtils.isValidBase64String(key)) {
-            errorMessage = "input publicKey is not a valid Base64 string.";
+        if (!DataToolUtils.isValidBase64String(key) && !isNumeric(key)) {
+            errorMessage = "input publicKey is not a valid Base64 string or Digit string.";
             throw new EncodeSuiteException(ErrorCode.ILLEGAL_INPUT, errorMessage);
         }
     }
@@ -94,9 +99,15 @@ public class EciesCryptoService implements CryptoService {
         logger.info("begin decrypt by ecies.");
         checkForDecrypt(content, key);
         String data = Numeric.toHexStringNoPrefix(Base64.decodeBase64(content));
-        BigInteger pri = new BigInteger(Base64.decodeBase64(key));
-        String priValue = Numeric.toHexStringNoPrefixZeroPadded(
-            pri, Keys.PRIVATE_KEY_LENGTH_IN_HEX);
+        String priValue = null;
+        if (isNumeric(key)) {
+            //如果为10进制数字
+            BigInteger bigInt = new BigInteger(key);
+            priValue = Numeric.toHexStringNoPrefixZeroPadded(
+                bigInt, Keys.PRIVATE_KEY_LENGTH_IN_HEX);
+        } else {
+            priValue = Numeric.toHexStringNoPrefix(Base64.decodeBase64(key));
+        }
         EciesResult deResult =  NativeInterface.eciesDecrypt(priValue, data);
         if (deResult != null) {
             if (StringUtils.isBlank(deResult.wedprErrorMessage)) {
@@ -128,9 +139,17 @@ public class EciesCryptoService implements CryptoService {
             throw new EncodeSuiteException(ErrorCode.ILLEGAL_INPUT, errorMessage);
         }
         // 检查privateKey是否为标准base64格式
-        if (!DataToolUtils.isValidBase64String(key)) {
-            errorMessage = "input privateKey is not a valid Base64 string.";
+        if (!DataToolUtils.isValidBase64String(key) && !isNumeric(key)) {
+            errorMessage = "input privateKey is not a valid Base64 string or Digit string.";
             throw new EncodeSuiteException(ErrorCode.ILLEGAL_INPUT, errorMessage);
         } 
+    }
+    
+    private static boolean isNumeric(final String str) {
+        // null or empty
+        if (str == null || str.length() == 0) {
+            return false;
+        }
+        return str.chars().allMatch(Character::isDigit);
     }
 }

--- a/src/main/java/com/webank/weid/util/CredentialPojoUtils.java
+++ b/src/main/java/com/webank/weid/util/CredentialPojoUtils.java
@@ -82,8 +82,7 @@ public final class CredentialPojoUtils {
             // Preserve the same behavior as in CredentialUtils - will merge later
             credMap.remove(ParamKeyConstant.PROOF);
             credMap.put(ParamKeyConstant.PROOF, null);
-            String claimHash = getClaimHash(credential, salt, disclosures);
-            credMap.put(ParamKeyConstant.CLAIM, claimHash);
+            credMap.put(ParamKeyConstant.CLAIM, getClaimHash(credential, salt, disclosures));
             return DataToolUtils.mapToCompactJson(credMap);
         } catch (Exception e) {
             logger.error("get Credential Thumbprint WithoutSig error.", e);
@@ -110,8 +109,7 @@ public final class CredentialPojoUtils {
             // Preserve the same behavior as in CredentialUtils - will merge later
             credMap.remove(ParamKeyConstant.PROOF);
             //credMap.put(ParamKeyConstant.PROOF, null);
-            String claimHash = getLiteClaimHash(credential);
-            credMap.put(ParamKeyConstant.CLAIM, claimHash);
+            credMap.put(ParamKeyConstant.CLAIM, getLiteClaimHash(credential));
             return DataToolUtils.mapToCompactJson(credMap);
         } catch (Exception e) {
             logger.error("get Credential Thumbprint WithoutSig error.", e);
@@ -190,8 +188,7 @@ public final class CredentialPojoUtils {
         try {
             Map<String, Object> credMap = DataToolUtils.objToMap(credential);
             // Replace the Claim value object with claim hash value to preserve immutability
-            String claimHash = getClaimHash(credential, salt, disclosures);
-            credMap.put(ParamKeyConstant.CLAIM, claimHash);
+            credMap.put(ParamKeyConstant.CLAIM, getClaimHash(credential, salt, disclosures));
             // Remove the whole Salt field to preserve immutability
             Map<String, Object> proof = (Map<String, Object>) credMap.get(ParamKeyConstant.PROOF);
             proof.remove(ParamKeyConstant.PROOF_SALT);
@@ -234,8 +231,7 @@ public final class CredentialPojoUtils {
         try {
             Map<String, Object> credMap = DataToolUtils.objToMap(credentialPojo);
             // Replace the Claim value object with claim hash value to preserve immutability
-            String claimHash = getLiteClaimHash(credentialPojo);
-            credMap.put(ParamKeyConstant.CLAIM, claimHash);
+            credMap.put(ParamKeyConstant.CLAIM, getLiteClaimHash(credentialPojo));
             // Remove the whole Salt field to preserve immutability
             Map<String, Object> proof = (Map<String, Object>) credMap.get(ParamKeyConstant.PROOF);
             proof.remove(ParamKeyConstant.PROOF_SALT);
@@ -460,20 +456,13 @@ public final class CredentialPojoUtils {
      * Get the lite credential claim hash.
      *
      * @param credential Credential
-     * @return the unique claim hash value
+     * @return the claimMap value
      */
-    public static String getLiteClaimHash(
+    public static Map<String, Object> getLiteClaimHash(
         CredentialPojo credential) {
 
         Map<String, Object> claim = credential.getClaim();
-        Map<String, Object> newClaim = DataToolUtils.clone((HashMap) claim);
-        try {
-            String jsonData = DataToolUtils.mapToCompactJson(newClaim);
-            return jsonData;
-        } catch (Exception e) {
-            logger.error("[getClaimHash] get claim hash failed. {}", e);
-        }
-        return StringUtils.EMPTY;
+        return  DataToolUtils.clone((HashMap) claim);
     }
 
     /**
@@ -482,9 +471,9 @@ public final class CredentialPojoUtils {
      * @param credential Credential
      * @param salt Salt Map
      * @param disclosures Disclosure Map
-     * @return the unique claim hash value
+     * @return the claimMap value
      */
-    public static String getClaimHash(
+    public static Map<String, Object> getClaimHash(
         CredentialPojo credential,
         Map<String, Object> salt,
         Map<String, Object> disclosures
@@ -493,13 +482,7 @@ public final class CredentialPojoUtils {
         Map<String, Object> claim = credential.getClaim();
         Map<String, Object> newClaim = DataToolUtils.clone((HashMap) claim);
         addSaltAndGetHash(newClaim, salt, disclosures);
-        try {
-            String jsonData = DataToolUtils.mapToCompactJson(newClaim);
-            return jsonData;
-        } catch (Exception e) {
-            logger.error("[getClaimHash] get claim hash failed. {}", e);
-        }
-        return StringUtils.EMPTY;
+        return newClaim;
     }
 
     private static void addSaltAndGetHash(


### PR DESCRIPTION
1. 优化加解密
2. 提供将10进制数字密钥转换成可用于加解密的base64字符串的方法
3. 提供将base64还原成10进制数字字符串密钥的方法
4. 新增用例，验证加解密和10进制和base64互转
5. 将所有签名和验签的数据中的json字符串去掉转义符
6. 修复验证失败时候的错误码返回